### PR TITLE
Addition of plugin for last update date time to pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,5 @@ jobs:
       - run: pip install mkdocs-material
       - run: pip install git+https://github.com/srymh/MkdocsTagPlugin.git@ac1f02ba95527d11d84b5ec87f4e63851d57fc7d
       - run: pip install git+https://github.com/rkoe/mkdocs-emailprotect@ef91e3dda367bd6a3f65dda183559e1b929d6240
+      - run: pip install mkdocs-git-revision-date-localized-plugin
       - run: mkdocs gh-deploy --force

--- a/Development.md
+++ b/Development.md
@@ -20,6 +20,7 @@ The plugins in use include
   * [Material Theme for mkdocs](https://squidfunk.github.io/mkdocs-material/)
   * [MkdocsTagPlugin - Support for Tags](https://github.com/srymh/MkdocsTagPlugin)
   * [Mkdocs Emailprotect - Additional protection for email address's against bots](https://github.com/rkoe/mkdocs-emailprotect)
+  * [mkdocs-git-revision-date-localized-plugin](https://github.com/timvink/mkdocs-git-revision-date-localized-plugin)
 
 There is a full list of plugins here
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ plugins:
   - mdoctag:
       tagpage_dir: 'tags'
       data_filename: 'tags.json'
+  - git-revision-date-localized
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/virtenv/dev_requirements.txt
+++ b/virtenv/dev_requirements.txt
@@ -7,3 +7,7 @@ git+https://github.com/srymh/MkdocsTagPlugin.git@ac1f02ba95527d11d84b5ec87f4e638
 
 # Protection for email links
 git+https://github.com/rkoe/mkdocs-emailprotect@ef91e3dda367bd6a3f65dda183559e1b929d6240
+
+# enables displaying the date of the last git modification of a page
+# https://github.com/timvink/mkdocs-git-revision-date-localized-plugin
+mkdocs-git-revision-date-localized-plugin


### PR DESCRIPTION
This should add last update date / time to each of the pages
as per https://github.com/HACManchester/documentation/issues/10

I could just put this through directly myself but I figured I'd get some feedback first before applying it.