### PR TITLE
Reorganise Telegram page

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:0-3.11",
+	"features": {
+		"ghcr.io/devcontainers-contrib/features/mkdocs:2": {}
+	},
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		8000
+	],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pip3 install --user -r virtenv/dev_requirements.txt",
+	"postStartCommand": "mkdocs serve"
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,9 +4,7 @@
 	"name": "Python 3",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/python:0-3.11",
-	"features": {
-		"ghcr.io/devcontainers-contrib/features/mkdocs:2": {}
-	},
+	"features": {},
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/docs/Telegram.md
+++ b/docs/Telegram.md
@@ -1,73 +1,68 @@
-Hacman Group Chat
------------------
+We have a number of group chats in [Telegram](https://telegram.org) that we encourage members to use to keep in touch, help each other out, and stay up to date with news and announcements.
 
-Hacman has [a Telegram group](https://t.me/HACManchester) which you are
-welcome to join!
+Some of these group chats are used to coordinate training for certain pieces of equipment.
 
-This contains many Hackspace members, as well as interested or
-interesting people. It's a good place to ask questions for a quick
-answer, ask for advice, or share news and links of interest to fellow
-hackers. There are [web](https://telegram.org/dl/webogram) clients for
-Telegram, as well as official clients for [Windows, Linux, OS
-X](https://desktop.telegram.org/),
-[Android](https://telegram.org/dl/android),
-[iOS](https://telegram.org/dl/ios), and [Windows
-Phone](https://telegram.org/dl/wp). You will need a phone number (not
-necessarily a UK one) to sign up for Telegram.
+Telegram has a number of clients for various platforms:
 
-Please familiarise yourself with our [Citizen Hacman
-Commitment](https://list.hacman.org.uk/t/citizen-hacman-a-revised-membership-agreement-and-hackspace-rules-final/2609)
-before chatting.
-
-#### Notifications
-
-This is a relatively high traffic channel (replacing IRC, which is no
-longer active). It's recommended that if using a phone app you disable
-notifications for the group (you will still receive notifications if
-someone sends you a PM, or if someone addresses or mentions you
-specifically).
-
-### Group Channels
-
-**Note we were using <http://protect-mylinks.com/addlinks> to avoid spam bots adding
-themselves to the channels, but it looks like they've started using annoying adds so that's been turned off**
-
-Several groups that look after parts of the hackspace have specific
-channels on telegram so they don't clog up the main channel.
-
--   Laser Training Group's [Telegram
-    group](https://t.me/joinchat/D5l4WUNG_uyg6YB0PYikRA) for
-    members who want training on the laser
--   Metalworking [Telegram
-    group](https://t.me/joinchat/B8-OC1MTETWTM8vBexJOag)
--   [Team Woodwork](Team_Woodwork "wikilink")'s [Telegram
-    group](https://t.me/joinchat/AYtZgkk7n1MqvkN9N2fmsA)
--   3d Printing [Telegram
-    group](https://t.me/joinchat/DZNJNRJimIP7XoyvDArnUg)
--   Hacman CNC [Telegram
-    Group](https://t.me/joinchat/AYtZgkh3BSRgpoA9LvQ3Hg)
--   Hacman Announcements [Telegram
-    Group](https://t.me/hackspaceannounce)
--   Hacman Games Night [Telegram
-    Group](https://t.me/joinchat/Ef01rUOXtWoUe3NHzQ-9QQ)
-
-TODO Expired Links
-
--   Notifications from the Hackscreen, including who's been in [Telegram
-    group](https://t.me/joinchat/Ef01rU1SrP9xJNmwXjHtWA)
--   [Team Procurement](Team_Procurement "wikilink")'s [Telegram
-    group](https://t.me/joinchat/D5l4WUPaGRQovcFCLd1X7g)
--   [Team Documentation](Team_Documentation "wikilink")'s [Telegram
-    group](https://t.me/joinchat/Agaj2UBrygQwTBBHDW8jyA)
--   [Team Event](Team_Events "wikilink")'s [Telegram
-    group](https://t.me/joinchat/E4DcrUDWGvEzlsmJHNNkuQ)
--   Space Bikes [Telegram
-    Group](https://t.me/joinchat/AoAv41LtXqjULCvqsbGwrA)
+- [Web client](https://telegram.org/dl/webogram) 
+- [Desktop (Windows, Linux, macOS)](https://desktop.telegram.org/)
+- [Android](https://telegram.org/dl/android)
+- [iOS](https://telegram.org/dl/ios)
+- [Windows Phone](https://telegram.org/dl/wp)
 
 
+You will need a phone number to sign up for Telegram. This is kept private and hidden from other Telegram users by default.
 
+## Notifications
 
-Groups exist for the following: [laser
-maintenance](Team_Laser "wikilink"), security, board, etc. These groups
-require training/election to join so please ask in the main channel if
-you are interested.
+Our group chats can be busy places. To avoid being overloaded by notifications, you may want to mute some or all of our groups.
+
+If you mute any groups, you may still receive notifications from them if another person directly mentions you or replies to one of your messages.
+
+## Groups
+
+The following tables list our group chats and their purpose. Click the group's name to join.
+
+> **Warning: Telegram rate limits**
+> 
+> To prevent abuse, Telegram limits the amount of groups you can join within 24 hours.
+>
+> To get chatting sooner than later, you might want to join groups you have the most interest in first.
+
+### General purpose
+
+| Group name                                               | Purpose                                                                                                                                            |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Hackspace Manchester](https://t.me/HACManchester)       | General purpose chat for all Hackspace Manchester members. Please do join this group.                                                              |
+| [Official Announcements](https://t.me/hackspaceannounce) | For example, news of members meetings, hack-the-space days, or certain outages / issues with the Hackspace or certain pieces of equipment          |
+| [Doorbot](https://t.me/+TVKs_4B85ksjAAVl)                | Access announcements – see who's visiting the space. To opt out, edit your account within the membership system and set "Announce Name" to "anon". |
+
+### Speciality groups
+
+For those interested in certain equipment, specialities, or hobbies.
+
+| Group name                                                  | Purpose                                                                                                                                     |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Woodwork](https://t.me/joinchat/AYtZgkk7n1MqvkN9N2fmsA)    | For any chatter relating to Woodworking, or matters relating to our Wood workshop.                                                          |
+| [Metalwork](https://t.me/joinchat/B8-OC1MTETWTM8vBexJOag)   | Similarly, anything relating to Metalwork or our Metal workshop.                                                                            |
+| [Electronics](https://t.me/+WLCJFgPE5LHX69XW)               | Anything relating to electronics in general, or our Electronics area.                                                                       |
+| [Visual Arts](https://t.me/hacmanvisualarts)                | Relating to our Visual Arts area,  any of the specialities within it, or visual arts in general.                                            |
+| [3D printing](https://t.me/joinchat/DZNJNRJimIP7XoyvDArnUg) | All things to do with 3D printing, or our own 3D printers.                                                                                  |
+| [Bike space](https://t.me/+hy1MtdfETqwzZmVk)                | For those with an interest in bikes, biking, or our collection of bike tools.                                                               |
+| [Games Night](https://t.me/+Q5e1aiVMwDvND71B)               | Board gaming & game night related chatter.                                                                                                  |
+| [Clutter Exchange](https://t.me/+11IEnLLuh8QxYWM0)          | See if any other members might be interest in anything you're wanting rid of: tools, equipment, material, or anything else possibly useful. |
+
+### Operations
+
+We have a number of groups specifically for the operation of the Hackspace overall.
+
+Some of these groups are private by default – in which case we'll list their existance, but you won't be able to join them from this page.
+
+| Group name                                                     | Purpose                                                                                                              |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| [Laser Training](https://t.me/joinchat/D5l4WUNG_uyg6YB0PYikRA) | To coordinate Laser training sessions between trainers and those waiting to be inducted.                             |
+| Laser Maintainers                                              | A private group for the maintainers of our Laser tools.                                                              |
+| [Open Evening Guides](https://t.me/+myuSy3MNMI8yMjQ0)          | Our members volunteer to run our open evening tours. If you're interested in helping out, this is the group to join. |
+| Digital Infrastructure Working Group                           | A private group for the members looking after our digital systems.                                                   |
+| Membership Subcommittee                                        | A private group to discuss membership issues                                                                         |
+| Membership System Log                                          | Logs from the Membership System, for our Digital team to keep an eye on.                                             |

--- a/docs/Telegram.md
+++ b/docs/Telegram.md
@@ -11,7 +11,7 @@ Telegram has a number of clients for various platforms:
 - [Windows Phone](https://telegram.org/dl/wp)
 
 
-You will need a phone number to sign up for Telegram. This is kept private and hidden from other Telegram users by default.
+You will need a phone number to sign up for Telegram. This is kept private and hidden from other Telegram users by default, although other Telegram users who already have your phone number in their address book will be notified that you have joined Telegram.
 
 ## Notifications
 
@@ -58,11 +58,11 @@ We have a number of groups specifically for the operation of the Hackspace overa
 
 Some of these groups are private by default – in which case we'll list their existance, but you won't be able to join them from this page.
 
-| Group name                                                     | Purpose                                                                                                              |
-| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| [Laser Training](https://t.me/joinchat/D5l4WUNG_uyg6YB0PYikRA) | To coordinate Laser training sessions between trainers and those waiting to be inducted.                             |
-| Laser Maintainers                                              | A private group for the maintainers of our Laser tools.                                                              |
-| [Open Evening Guides](https://t.me/+myuSy3MNMI8yMjQ0)          | Our members volunteer to run our open evening tours. If you're interested in helping out, this is the group to join. |
-| Digital Infrastructure Working Group                           | A private group for the members looking after our digital systems.                                                   |
-| Membership Subcommittee                                        | A private group to discuss membership issues                                                                         |
-| Membership System Log                                          | Logs from the Membership System, for our Digital team to keep an eye on.                                             |
+| Group name                                            | Purpose                                                                                                                                                                                                           |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Open Evening Guides](https://t.me/+myuSy3MNMI8yMjQ0) | Our members volunteer to run our open evening tours. If you're interested in helping out, this is the group to join.                                                                                              |
+| Laser Training                                        | Used to coordinate Laser training sessions between trainers and those waiting to be inducted. You will be given a link to this group after requesting an induction on our Laser Cutter via the membership system. |
+| Laser Maintainers                                     | A private group for the maintainers of our Laser tools.                                                                                                                                                           |
+| Digital Infrastructure Working Group                  | A private group for the members looking after our digital systems.                                                                                                                                                |
+| Membership Subcommittee                               | A private group to discuss membership issues                                                                                                                                                                      |
+| Membership System Log                                 | Logs from the Membership System, for our Digital team to keep an eye on.                                                                                                                                          |


### PR DESCRIPTION
**Context**

As raised in our January 2023 Members Meeting, we have numerous Telegram group chats. Some of which are linked to from the docs site, some of which are referenced in pinned messages, and others which may be nested in other group's pinned messages.

The breadth of chats we have any the many different places we link to them pose a discoverability problem.

To improve the new membership experience, I'll be proposing many changes on a member's dashboard later on – including a link to this Telegram page. Before I progress that, I wanted to give this page a tidy up first.

**Changes**

I've approached this by rewriting the page top-to-bottom, introducing some formatting and tables to – hopefully – make the page easier to read.

I've also completely removed the original list of channels, as many of the links appeared to have expired, and instead taken the latest list from the pinned message last-updated on Jan 28th 2023.

We may have more Telegram channels than are listed here. If there are any more that I've missed – because I'm not aware of them – please do let me know.

For some of our private operational-related channels, whilst they're not open for members to freely join I would prefer we list them on this page – just without an invite link. I do think it would be helpful to have one centralised, complete list of our Telegram groups.

**devcontainer.json file**

This PR also contains a `devcontainer.json` file. This is a developer-related configuration which makes it easier to run the docs system in a development environment.

This file has no impact on the final, deployed, documentation site.

**Preview**

Whilst we are hosted on Github Pages, I don't think we are able to have PR-specific preview builds.

Instead, I've temporarily deployed a build of the docs site on my own Netlify account.

[See a preview of the new Telegram page](https://delicate-gumdrop-a6d75a.netlify.app/telegram/)