### PR TITLE
Open Evenings page

### DIFF
--- a/docs/Open_Evenings.md
+++ b/docs/Open_Evenings.md
@@ -1,0 +1,22 @@
+**We hold open evenings every Wednesday evening, where we host 3 tours at 6:30pm, 7:30pm, and 8:30pm.**
+
+These are free to attend. Just turn up, give our doorbell a ring, and we'll show you around.
+
+Each tour will last about 20 minutes, during which a couple of your fellow members will:
+
+- Walk you through what tools, equipment, and facilities we have
+- Talk through general safety practices, and how you can request training for any equipment that requires it
+- Give you some ideas of how you can get involved with the space – we are a member managed space afterall
+- And answer any questions you might have
+
+All members must attend one of these tours before being given access to the Hackspace.
+
+If you've already signed up as a member, or you choose to do so during the open evening, we'll set up your access fob for 24/7 access to the Hackspace.
+
+## How to find us
+
+We are in the ground floor of Wellington House in Ancoats, behind the sunset-skyline painted door. See the [Find Us](https://www.hacman.org.uk/find-us/) page on our website for our exact address and transport guidance.
+
+Once you've found our front door, there's a green doorbell you can press to let us know you've arrived.
+
+![Hackspace Manchester front door](https://www.hacman.org.uk/wp-content/uploads/2021/10/photo_2021-09-29_13-57-07.jpg)

--- a/docs/Open_Evenings.md
+++ b/docs/Open_Evenings.md
@@ -6,10 +6,10 @@ Each tour will last about 20 minutes, during which a couple of your fellow membe
 
 - Walk you through what tools, equipment, and facilities we have
 - Talk through general safety practices, and how you can request training for any equipment that requires it
-- Give you some ideas of how you can get involved with the space – we are a member managed space afterall
+- Let you know how to get involved – our community runs the space
 - And answer any questions you might have
 
-All members must attend one of these tours before being given access to the Hackspace.
+All members must attend a tour before gaining independent access to the Hackspace.
 
 If you've already signed up as a member, or you choose to do so during the open evening, we'll set up your access fob for 24/7 access to the Hackspace.
 


### PR DESCRIPTION
**Context**

As part of the wider new-member-experience improvements, one of the changes I'm working on for the membership system is a new "Getting Started" panel to walk new members through setting up their membership and getting access to the space.

![Screenshot 2023-02-05 at 18 20 36](https://user-images.githubusercontent.com/602850/216837608-242a6809-4360-478f-ab97-c07b880c7add.png)

(This is not final of course. I've yet to complete and raise a PR for my proposed dashboard tweaks)

We recently decided that new members must attend our open evening tours for an in-person induction before we are able to give them free access to the Hackspace. For the last step of the "Getting Started" panel, I'm therefore wanting a page that describes our open evenings and when they are.

**Change**

This pull request proposes a draft Open Evenings page on our docs site.

In the digital chat, there was a mention of creating this page on our main Wordpress website. I've logged into Wordpress and had a look around, but I don't feel comfortable throwing something together on the live website quite yet. We could do that later, but right now I just want a page on open evenings _somewhere_ and the docs seem like the easiest place to put it.

**Preview**

As with my Telegram PR, I have uploaded a temporary build of this change to Netlify to give us a preview.

[Click here to preview the proposed Open Evenings page](https://delightful-kleicha-efc575.netlify.app/open_evenings/)